### PR TITLE
Improve RGB processing for SK9822.

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -6,6 +6,29 @@ bring it to our attention by posting an issue.
 
 The attached notices are provided for information only.
 
+License notice for FastLED
+--------------------------
+The MIT License (MIT)
+
+Copyright (c) 2013 FastLED
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 License notice for Manrope
 --------------------------
 

--- a/src/Aether/Devices/Drivers/AddressableRgbDriver.cs
+++ b/src/Aether/Devices/Drivers/AddressableRgbDriver.cs
@@ -1,4 +1,6 @@
-﻿namespace Aether.Devices.Drivers
+﻿using SixLabors.ImageSharp.ColorSpaces;
+
+namespace Aether.Devices.Drivers
 {
     public abstract class AddressableRgbDriver
     {
@@ -8,6 +10,14 @@
         {
             LedCount = ledCount;
         }
+
+        /// <summary>
+        /// Converts a linear RGB value and a global brightness into a <see cref="LedPixel"/>.
+        /// </summary>
+        /// <param name="rgb">The color to create, in linear RGB.</param>
+        /// <param name="brightness">A global brightness value, from 0 to 1.</param>
+        /// <returns></returns>
+        public abstract LedPixel CreatePixelColor(in LinearRgb rgb, float brightness);
 
         public abstract void SetLeds(ReadOnlySpan<LedPixel> pixels);
     }

--- a/src/Aether/Devices/Drivers/LedPixel.cs
+++ b/src/Aether/Devices/Drivers/LedPixel.cs
@@ -1,4 +1,11 @@
 ﻿namespace Aether.Devices.Drivers
 {
+    /// <summary>
+    /// An abstract pixel, created from <see cref="AddressableRgbDriver.CreatePixelColor(in SixLabors.ImageSharp.ColorSpaces.LinearRgb, float)"/>.
+    /// </summary>
+    /// <param name="Brightness">The pixel's global brightness.</param>
+    /// <param name="R">The pixel's red component.</param>
+    /// <param name="G">The pixel's green component.</param>
+    /// <param name="B">The pixel's blue component.</param>
     public readonly record struct LedPixel(byte Brightness, byte R, byte G, byte B);
 }

--- a/src/Aether/Themes/RgbTheme.cs
+++ b/src/Aether/Themes/RgbTheme.cs
@@ -108,17 +108,11 @@ namespace Aether.Themes
                     float g = (float)(from.G + (to.G - from.G) * lerp);
                     float b = (float)(from.B + (to.B - from.B) * lerp);
 
-                    Rgb rgb = colorConverter.ToRgb(new LinearRgb(r, g, b));
-
-                    // And convert the sRGB color to a pixel color.
-
-                    byte ri = (byte)Convert.ToInt32(Math.Clamp(rgb.R * 255.0f, 0.0f, 255.0f));
-                    byte gi = (byte)Convert.ToInt32(Math.Clamp(rgb.G * 255.0f, 0.0f, 255.0f));
-                    byte bi = (byte)Convert.ToInt32(Math.Clamp(rgb.B * 255.0f, 0.0f, 255.0f));
-
-                    var color = new LedPixel(Brightness: 16, ri, gi, bi);
+                    var rgb = new LinearRgb(r, g, b);
 
                     // Update LEDs, if there's a change.
+
+                    LedPixel color = display.CreatePixelColor(rgb, brightness: 0.05f);
 
                     if (color != prevColor || firstAlertPixelIdx != prevFirstAlertPixelIdx)
                     {
@@ -133,7 +127,7 @@ namespace Aether.Themes
 
                         if (firstAlertPixelIdx != -1)
                         {
-                            LedPixel brightColor = color with { Brightness = 255 };
+                            LedPixel brightColor = display.CreatePixelColor(rgb, brightness: 1.0f);
                             int idx = firstAlertPixelIdx;
 
                             for (int i = 0; i < AlertPixelCount; ++i)


### PR DESCRIPTION
This makes RGB brightness more even, reduces rounding error in the color pipeline, and improves draw performance.