### PR TITLE
Misc improvements

### DIFF
--- a/src/Aether/CustomUnits/AirQualityIndex.cs
+++ b/src/Aether/CustomUnits/AirQualityIndex.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using UnitsNet;
 
 namespace Aether.CustomUnits
@@ -8,66 +9,114 @@ namespace Aether.CustomUnits
         EPA
     }
 
-    public struct AirQualityIndex : IQuantity
+    public readonly struct AirQualityIndex : IQuantity<AirQualityIndexUnit>, IEquatable<AirQualityIndex>
     {
+        public static AirQualityIndex Zero => new AirQualityIndex(0);
+
+        public static QuantityInfo<AirQualityIndexUnit> Info { get; } = new QuantityInfo<AirQualityIndexUnit>(
+            nameof(AirQualityIndex),
+            new UnitInfo<AirQualityIndexUnit>[]
+            {
+                new (AirQualityIndexUnit.EPA, BaseUnits.Undefined)
+            },
+            AirQualityIndexUnit.EPA,
+            Zero,
+            BaseDimensions.Dimensionless);
+
+        public AirQualityIndexUnit Unit { get; }
+
+        Enum IQuantity.Unit =>
+            Unit;
+
+        public double Value { get; }
+
+        public QuantityType Type =>
+            QuantityType.Information;
+
+        public BaseDimensions Dimensions =>
+            BaseDimensions.Dimensionless;
+
+        public QuantityInfo<AirQualityIndexUnit> QuantityInfo =>
+            Info;
+
+        QuantityInfo IQuantity.QuantityInfo =>
+            QuantityInfo;
+
+        static AirQualityIndex()
+        {
+            UnitAbbreviationsCache.Default.MapUnitToAbbreviation(AirQualityIndexUnit.EPA, "AQI");
+        }
+
         public AirQualityIndex(double value, AirQualityIndexUnit unit = AirQualityIndexUnit.EPA)
         {
             Unit = unit;
             Value = value;
         }
 
-        Enum IQuantity.Unit => Unit;
-        public AirQualityIndexUnit Unit { get; }
-
-        public double Value { get; }
-
-        #region IQuantity
-
-        private static readonly AirQualityIndex Zero = new AirQualityIndex(0, AirQualityIndexUnit.EPA);
-
-        public QuantityType Type => QuantityType.Information;
-        public BaseDimensions Dimensions => BaseDimensions.Dimensionless;
-
-        public QuantityInfo QuantityInfo => new QuantityInfo(
-            nameof(AirQualityIndexUnit),
-            typeof(AirQualityIndexUnit),
-            new UnitInfo[]
-            {
-                new UnitInfo<AirQualityIndexUnit>(AirQualityIndexUnit.EPA, BaseUnits.Undefined)
-            },
-            AirQualityIndexUnit.EPA,
-            Zero,
-            BaseDimensions.Dimensionless);
-
-        public double As(Enum unit) => unit is AirQualityIndexUnit airQualityIndexUnit
+        public double As(AirQualityIndexUnit unit) =>
+            unit == AirQualityIndexUnit.EPA
             ? Value
-            : throw new ArgumentException($"Must be of type {nameof(AirQualityIndexUnit)}.", nameof(unit));
+            : throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
+
+        double IQuantity.As(Enum unit) =>
+            unit is AirQualityIndexUnit aqi
+            ? As(aqi)
+            : throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AirQualityIndexUnit)} is supported.", nameof(unit));
 
         public double As(UnitSystem unitSystem) =>
-            throw new NotImplementedException();
+            Info.GetUnitInfosFor(unitSystem.BaseUnits).FirstOrDefault() is UnitInfo<AirQualityIndexUnit> info
+            ? As(info.Value)
+            : throw new ArgumentException($"No units were found for the given {nameof(UnitSystem)}.", nameof(unitSystem));
 
-        public IQuantity ToUnit(Enum unit) => unit is AirQualityIndexUnit airQualityIndexUnit
+        public AirQualityIndex ToUnit(AirQualityIndexUnit unit) =>
+            unit == AirQualityIndexUnit.EPA
             ? this
+            : throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
+
+        IQuantity<AirQualityIndexUnit> IQuantity<AirQualityIndexUnit>.ToUnit(AirQualityIndexUnit unit) =>
+            ToUnit(unit);
+
+        IQuantity IQuantity.ToUnit(Enum unit) =>
+            unit is AirQualityIndexUnit aqi
+            ? ToUnit(aqi)
             : throw new ArgumentException($"Must be of type {nameof(AirQualityIndexUnit)}.", nameof(unit));
 
-        public IQuantity ToUnit(UnitSystem unitSystem) =>
-            throw new NotImplementedException();
+        public AirQualityIndex ToUnit(UnitSystem unitSystem) =>
+            Info.GetUnitInfosFor(unitSystem.BaseUnits).FirstOrDefault() is UnitInfo<AirQualityIndexUnit> info
+            ? ToUnit(info.Value)
+            : throw new ArgumentException($"No units were found for the given {nameof(UnitSystem)}.", nameof(unitSystem));
 
-        public override string ToString() =>
-            ToString(CultureInfo.CurrentCulture);
+        IQuantity<AirQualityIndexUnit> IQuantity<AirQualityIndexUnit>.ToUnit(UnitSystem unitSystem) =>
+            ToUnit(unitSystem);
+
+        IQuantity IQuantity.ToUnit(UnitSystem unitSystem) =>
+            ToUnit(unitSystem);
 
         public string ToString(string? format, IFormatProvider? formatProvider) =>
-            Value.ToString(format, formatProvider);
+            QuantityFormatter.Format(this, format ?? "g", formatProvider);
+
+        public override string ToString() =>
+            ToString(null, null);
 
         public string ToString(IFormatProvider? provider) =>
-            ToString("N0", provider);
+            ToString(null, provider);
 
-        string IQuantity.ToString(IFormatProvider? provider, int significantDigitsAfterRadix) =>
-            throw new NotImplementedException();
+        string IQuantity.ToString(IFormatProvider? provider, int significantDigitsAfterRadix)
+        {
+            string format = string.Create(CultureInfo.InvariantCulture, $"s{significantDigitsAfterRadix}");
+            return ToString(format, provider);
+        }
 
         string IQuantity.ToString(IFormatProvider? provider, string format, params object[] args) =>
             throw new NotImplementedException();
 
-        #endregion
+        public bool Equals(AirQualityIndex other) =>
+            other.As(Unit).Equals(Value);
+
+        public override bool Equals([NotNullWhen(true)] object? obj) =>
+            obj is AirQualityIndex other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(Info.Name, Value, Unit);
     }
 }

--- a/src/Aether/CustomUnits/NumberConcentration.cs
+++ b/src/Aether/CustomUnits/NumberConcentration.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using UnitsNet;
 
 namespace Aether.CustomUnits
@@ -12,54 +9,114 @@ namespace Aether.CustomUnits
         ParticulatePerCubicCentimeter
     }
 
-    public struct NumberConcentration : IQuantity
+    public readonly struct NumberConcentration : IQuantity<NumberConcentrationUnit>, IEquatable<NumberConcentration>
     {
+        public static NumberConcentration Zero => new NumberConcentration(0);
+
+        public static QuantityInfo<NumberConcentrationUnit> Info { get; } = new QuantityInfo<NumberConcentrationUnit>(
+            nameof(NumberConcentration),
+            new UnitInfo<NumberConcentrationUnit>[]
+            {
+                new (NumberConcentrationUnit.ParticulatePerCubicCentimeter, BaseUnits.Undefined)
+            },
+            NumberConcentrationUnit.ParticulatePerCubicCentimeter,
+            Zero,
+            BaseDimensions.Dimensionless);
+
+        public NumberConcentrationUnit Unit { get; }
+
+        Enum IQuantity.Unit =>
+            Unit;
+
+        public double Value { get; }
+
+        public QuantityType Type =>
+            QuantityType.Information;
+
+        public BaseDimensions Dimensions =>
+            BaseDimensions.Dimensionless;
+
+        public QuantityInfo<NumberConcentrationUnit> QuantityInfo =>
+            Info;
+
+        QuantityInfo IQuantity.QuantityInfo =>
+            QuantityInfo;
+
+        static NumberConcentration()
+        {
+            UnitAbbreviationsCache.Default.MapUnitToAbbreviation(NumberConcentrationUnit.ParticulatePerCubicCentimeter, "per cm³");
+        }
+
         public NumberConcentration(double value, NumberConcentrationUnit unit = NumberConcentrationUnit.ParticulatePerCubicCentimeter)
         {
             Unit = unit;
             Value = value;
         }
 
-        Enum IQuantity.Unit => Unit;
-        public NumberConcentrationUnit Unit { get; }
+        public double As(NumberConcentrationUnit unit) =>
+            unit == NumberConcentrationUnit.ParticulatePerCubicCentimeter
+            ? Value
+            : throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
 
-        public double Value { get; }
+        double IQuantity.As(Enum unit) =>
+            unit is NumberConcentrationUnit nc
+            ? As(nc)
+            : throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(NumberConcentrationUnit)} is supported.", nameof(unit));
 
-        #region IQuantity
+        public double As(UnitSystem unitSystem) =>
+            Info.GetUnitInfosFor(unitSystem.BaseUnits).FirstOrDefault() is UnitInfo<NumberConcentrationUnit> info
+            ? As(info.Value)
+            : throw new ArgumentException($"No units were found for the given {nameof(UnitSystem)}.", nameof(unitSystem));
 
-        private static readonly NumberConcentration Zero = new NumberConcentration(0, NumberConcentrationUnit.ParticulatePerCubicCentimeter);
+        public NumberConcentration ToUnit(NumberConcentrationUnit unit) =>
+            unit == NumberConcentrationUnit.ParticulatePerCubicCentimeter
+            ? this
+            : throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
 
-        public QuantityType Type => QuantityType.Information;
-        public BaseDimensions Dimensions => BaseDimensions.Dimensionless;
+        IQuantity<NumberConcentrationUnit> IQuantity<NumberConcentrationUnit>.ToUnit(NumberConcentrationUnit unit) =>
+            ToUnit(unit);
 
-        public QuantityInfo QuantityInfo => new QuantityInfo("NumberConcentrationUnit", typeof(NumberConcentrationUnit),
-            new UnitInfo[]
-            {
-                new UnitInfo<NumberConcentrationUnit>(NumberConcentrationUnit.ParticulatePerCubicCentimeter, BaseUnits.Undefined)
-            },
-            NumberConcentrationUnit.ParticulatePerCubicCentimeter,
-            Zero,
-            BaseDimensions.Dimensionless);
+        IQuantity IQuantity.ToUnit(Enum unit) =>
+            unit is NumberConcentrationUnit nc
+            ? ToUnit(nc)
+            : throw new ArgumentException($"Must be of type {nameof(NumberConcentrationUnit)}.", nameof(unit));
 
-        public double As(Enum unit) => Convert.ToDouble(unit);
+        public NumberConcentration ToUnit(UnitSystem unitSystem) =>
+            Info.GetUnitInfosFor(unitSystem.BaseUnits).FirstOrDefault() is UnitInfo<NumberConcentrationUnit> info
+            ? ToUnit(info.Value)
+            : throw new ArgumentException($"No units were found for the given {nameof(UnitSystem)}.", nameof(unitSystem));
 
-        public double As(UnitSystem unitSystem) => throw new NotImplementedException();
+        IQuantity<NumberConcentrationUnit> IQuantity<NumberConcentrationUnit>.ToUnit(UnitSystem unitSystem) =>
+            ToUnit(unitSystem);
 
-        public IQuantity ToUnit(Enum unit)
+        IQuantity IQuantity.ToUnit(UnitSystem unitSystem) =>
+            ToUnit(unitSystem);
+
+        public string ToString(string? format, IFormatProvider? formatProvider) =>
+            QuantityFormatter.Format(this, format ?? "g", formatProvider);
+
+        public override string ToString() =>
+            ToString(null, null);
+
+        public string ToString(IFormatProvider? provider) =>
+            ToString(null, provider);
+
+        string IQuantity.ToString(IFormatProvider? provider, int significantDigitsAfterRadix)
         {
-            if (unit is NumberConcentrationUnit numberConcentrationUnit)
-                return new NumberConcentration(As(unit), numberConcentrationUnit);
-            throw new ArgumentException("Must be of type NumberConcentrationUnit.", nameof(unit));
+            string format = string.Create(CultureInfo.InvariantCulture, $"s{significantDigitsAfterRadix}");
+            return ToString(format, provider);
         }
 
-        public IQuantity ToUnit(UnitSystem unitSystem) => throw new NotImplementedException();
+        string IQuantity.ToString(IFormatProvider? provider, string format, params object[] args) =>
+            throw new NotImplementedException();
 
-        public override string ToString() => $"{string.Format("{0:0.00}", Value)}/cm³";
-        public string ToString(string? format, IFormatProvider? formatProvider) => $"Number Concentration ({format}, {formatProvider})";
-        public string ToString(IFormatProvider? provider) => $"Number Concentration ({provider})";
-        public string ToString(IFormatProvider? provider, int significantDigitsAfterRadix) => $"Number Concentration ({provider}, {significantDigitsAfterRadix})";
-        public string ToString(IFormatProvider? provider, string format, params object[] args) => $"Number Concentration ({provider}, {string.Join(", ", args)})";
+        public bool Equals(NumberConcentration other) =>
+            other.As(Unit).Equals(Value);
 
-        #endregion
+        public override bool Equals([NotNullWhen(true)] object? obj) =>
+            obj is NumberConcentration other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(Info.Name, Value, Unit);
     }
 }

--- a/src/Aether/CustomUnits/VolatileOrganicCompoundIndex.cs
+++ b/src/Aether/CustomUnits/VolatileOrganicCompoundIndex.cs
@@ -1,4 +1,6 @@
-﻿using UnitsNet;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using UnitsNet;
 
 namespace Aether.CustomUnits
 {
@@ -7,54 +9,114 @@ namespace Aether.CustomUnits
         IndexValue
     }
 
-    public struct VolatileOrganicCompoundIndex : IQuantity
+    public readonly struct VolatileOrganicCompoundIndex : IQuantity<VolatileOrganicCompoundIndexUnit>, IEquatable<VolatileOrganicCompoundIndex>
     {
+        public static VolatileOrganicCompoundIndex Zero => new VolatileOrganicCompoundIndex(0);
+
+        public static QuantityInfo<VolatileOrganicCompoundIndexUnit> Info { get; } = new QuantityInfo<VolatileOrganicCompoundIndexUnit>(
+            nameof(VolatileOrganicCompoundIndex),
+            new UnitInfo<VolatileOrganicCompoundIndexUnit>[]
+            {
+                new (VolatileOrganicCompoundIndexUnit.IndexValue, BaseUnits.Undefined)
+            },
+            VolatileOrganicCompoundIndexUnit.IndexValue,
+            Zero,
+            BaseDimensions.Dimensionless);
+
+        public VolatileOrganicCompoundIndexUnit Unit { get; }
+
+        Enum IQuantity.Unit =>
+            Unit;
+
+        public double Value { get; }
+
+        public QuantityType Type =>
+            QuantityType.Information;
+
+        public BaseDimensions Dimensions =>
+            BaseDimensions.Dimensionless;
+
+        public QuantityInfo<VolatileOrganicCompoundIndexUnit> QuantityInfo =>
+            Info;
+
+        QuantityInfo IQuantity.QuantityInfo =>
+            QuantityInfo;
+
+        static VolatileOrganicCompoundIndex()
+        {
+            UnitAbbreviationsCache.Default.MapUnitToAbbreviation(VolatileOrganicCompoundIndexUnit.IndexValue, "VOC Idx");
+        }
+
         public VolatileOrganicCompoundIndex(double value, VolatileOrganicCompoundIndexUnit unit = VolatileOrganicCompoundIndexUnit.IndexValue)
         {
             Unit = unit;
             Value = value;
         }
 
-        Enum IQuantity.Unit => Unit;
-        public VolatileOrganicCompoundIndexUnit Unit { get; }
+        public double As(VolatileOrganicCompoundIndexUnit unit) =>
+            unit == VolatileOrganicCompoundIndexUnit.IndexValue
+            ? Value
+            : throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
 
-        public double Value { get; }
+        double IQuantity.As(Enum unit) =>
+            unit is VolatileOrganicCompoundIndexUnit voc
+            ? As(voc)
+            : throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(VolatileOrganicCompoundIndexUnit)} is supported.", nameof(unit));
 
-        #region IQuantity
+        public double As(UnitSystem unitSystem) =>
+            Info.GetUnitInfosFor(unitSystem.BaseUnits).FirstOrDefault() is UnitInfo<VolatileOrganicCompoundIndexUnit> info
+            ? As(info.Value)
+            : throw new ArgumentException($"No units were found for the given {nameof(UnitSystem)}.", nameof(unitSystem));
 
-        private static readonly VolatileOrganicCompoundIndex Zero = new VolatileOrganicCompoundIndex(0, VolatileOrganicCompoundIndexUnit.IndexValue);
+        public VolatileOrganicCompoundIndex ToUnit(VolatileOrganicCompoundIndexUnit unit) =>
+            unit == VolatileOrganicCompoundIndexUnit.IndexValue
+            ? this
+            : throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
 
-        public QuantityType Type => QuantityType.Information;
-        public BaseDimensions Dimensions => BaseDimensions.Dimensionless;
+        IQuantity<VolatileOrganicCompoundIndexUnit> IQuantity<VolatileOrganicCompoundIndexUnit>.ToUnit(VolatileOrganicCompoundIndexUnit unit) =>
+            ToUnit(unit);
 
-        public QuantityInfo QuantityInfo => new QuantityInfo("IndexUnit", typeof(VolatileOrganicCompoundIndexUnit),
-            new UnitInfo[]
-            {
-                new UnitInfo<VolatileOrganicCompoundIndexUnit>(VolatileOrganicCompoundIndexUnit.IndexValue, BaseUnits.Undefined)
-            },
-            VolatileOrganicCompoundIndexUnit.IndexValue,
-            Zero,
-            BaseDimensions.Dimensionless);
+        IQuantity IQuantity.ToUnit(Enum unit) =>
+            unit is VolatileOrganicCompoundIndexUnit vocIndexUnit
+            ? ToUnit(vocIndexUnit)
+            : throw new ArgumentException($"Must be of type {nameof(VolatileOrganicCompoundIndexUnit)}.", nameof(unit));
 
-        public double As(Enum unit) => Convert.ToDouble(unit);
+        public VolatileOrganicCompoundIndex ToUnit(UnitSystem unitSystem) =>
+            Info.GetUnitInfosFor(unitSystem.BaseUnits).FirstOrDefault() is UnitInfo<VolatileOrganicCompoundIndexUnit> info
+            ? ToUnit(info.Value)
+            : throw new ArgumentException($"No units were found for the given {nameof(UnitSystem)}.", nameof(unitSystem));
 
-        public double As(UnitSystem unitSystem) => throw new NotImplementedException();
+        IQuantity<VolatileOrganicCompoundIndexUnit> IQuantity<VolatileOrganicCompoundIndexUnit>.ToUnit(UnitSystem unitSystem) =>
+            ToUnit(unitSystem);
 
-        public IQuantity ToUnit(Enum unit)
+        IQuantity IQuantity.ToUnit(UnitSystem unitSystem) =>
+            ToUnit(unitSystem);
+
+        public string ToString(string? format, IFormatProvider? formatProvider) =>
+            QuantityFormatter.Format(this, format ?? "g", formatProvider);
+
+        public override string ToString() =>
+            ToString(null, null);
+
+        public string ToString(IFormatProvider? provider) =>
+            ToString(null, provider);
+
+        string IQuantity.ToString(IFormatProvider? provider, int significantDigitsAfterRadix)
         {
-            if (unit is VolatileOrganicCompoundIndexUnit vocIndexUnit)
-                return new VolatileOrganicCompoundIndex(As(unit), vocIndexUnit);
-            throw new ArgumentException("Must be of type VolatileOrganicCompoundIndexUnit.", nameof(unit));
+            string format = string.Create(CultureInfo.InvariantCulture, $"s{significantDigitsAfterRadix}");
+            return ToString(format, provider);
         }
 
-        public IQuantity ToUnit(UnitSystem unitSystem) => throw new NotImplementedException();
+        string IQuantity.ToString(IFormatProvider? provider, string format, params object[] args) =>
+            throw new NotImplementedException();
 
-        public override string ToString() => $"Volatile Organic Compound Index Value: {Value}";
-        public string ToString(string? format, IFormatProvider? formatProvider) => $"Volatile Organic Compound Index ({format}, {formatProvider})";
-        public string ToString(IFormatProvider? provider) => $"Volatile Organic Compound Index ({provider})";
-        public string ToString(IFormatProvider? provider, int significantDigitsAfterRadix) => $"Volatile Organic Compound Index ({provider}, {significantDigitsAfterRadix})";
-        public string ToString(IFormatProvider? provider, string format, params object[] args) => $"Volatile Organic Compound Index ({provider}, {string.Join(", ", args)})";
+        public bool Equals(VolatileOrganicCompoundIndex other) =>
+            other.As(Unit).Equals(Value);
 
-        #endregion
+        public override bool Equals([NotNullWhen(true)] object? obj) =>
+            obj is VolatileOrganicCompoundIndex other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(Info.Name, Value, Unit);
     }
 }

--- a/src/Aether/Program.cs
+++ b/src/Aether/Program.cs
@@ -51,6 +51,9 @@ runDeviceCommand.Handler = CommandHandler.Create(async () =>
         measurements,
         ObservableAirQualityIndex.GetAirQualityIndex(measurements));
 
+    // Ref count measurements, which will be used in a few places.
+    measurements = measurements.Publish().RefCount();
+
     // Initialize ePaper display.
     var spiConfig = new SpiConnectionSettings(0, 0)
     {

--- a/src/Aether/Reactive/AetherObservable.cs
+++ b/src/Aether/Reactive/AetherObservable.cs
@@ -64,7 +64,10 @@ namespace Aether.Reactive
         public static IObservable<IList<T>> Gate<T>(this IObservable<T> observable) =>
             Observable.Create(async (IObserver<IList<T>> observer, CancellationToken cancellationToken) =>
             {
-                Channel<T> channel = Channel.CreateUnbounded<T>();
+                Channel<T> channel = Channel.CreateUnbounded<T>(new UnboundedChannelOptions
+                {
+                    SingleReader = true
+                });
 
                 using CancellationTokenRegistration reg = cancellationToken.UnsafeRegister(static obj => ((ChannelWriter<T>)obj!).TryComplete(), channel.Writer);
 

--- a/src/Aether/Themes/MultiLineTheme.cs
+++ b/src/Aether/Themes/MultiLineTheme.cs
@@ -233,6 +233,7 @@ namespace Aether.Themes
             Measure.PM2_5 => "PM₂.₅\nμg/m³",
             Measure.PM4_0 => "PM₄.₀\nμg/m³",
             Measure.PM10_0 => "PM₁₀.₀\nμg/m³",
+            Measure.P0_5 => "PM₀.₅\n#/cm³",
             Measure.P1_0 => "PM₁.₀\n#/cm³",
             Measure.P2_5 => "PM₂.₅\n#/cm³",
             Measure.P4_0 => "PM₄.₀\n#/cm³",

--- a/src/Aether/Themes/MultiLineTheme.cs
+++ b/src/Aether/Themes/MultiLineTheme.cs
@@ -157,6 +157,7 @@ namespace Aether.Themes
             // TODO: abstract and localize stringy bits.
 
             var seen = new HashSet<Measure>();
+            var previousValues = new Dictionary<Measure, string>();
             Point location = default;
             string text;
 
@@ -186,21 +187,28 @@ namespace Aether.Themes
                         continue;
                     }
 
-                    draw = true;
-
                     text = measurement.Measure switch
                     {
                         Measure.Humidity => (measurement.RelativeHumidity.Value * (1.0 / 100.0)).ToString("P0"),
                         Measure.Temperature => measurement.Temperature.DegreesFahrenheit.ToString("N1"),
                         Measure.CO2 => measurement.Co2.PartsPerMillion.ToString("N0"),
                         Measure.BarometricPressure => measurement.BarometricPressure.Atmospheres.ToString("N2"),
-                        Measure.VOC => measurement.Voc.Value.ToString(),
+                        Measure.VOC => measurement.Voc.Value.ToString("N0"),
                         Measure.PM1_0 or Measure.PM2_5 or Measure.PM4_0 or Measure.PM10_0 => measurement.MassConcentration.MicrogramsPerCubicMeter.ToString("N0"),
-                        Measure.P1_0 or Measure.P2_5 or Measure.P4_0 or Measure.P10_0 => measurement.NumberConcentration.Value.ToString("N0"),
+                        Measure.P0_5 or Measure.P1_0 or Measure.P2_5 or Measure.P4_0 or Measure.P10_0 => measurement.NumberConcentration.Value.ToString("N0"),
                         Measure.TypicalParticleSize => measurement.Length.Micrometers.ToString("N1"),
                         Measure.AirQualityIndex => measurement.AirQualityIndex.Value.ToString("N0"),
                         _ => throw new Exception($"Unsupported measure '{measurement.Measure}'.")
                     };
+
+                    if (previousValues.TryGetValue(measurement.Measure, out string? prevText) && prevText == text)
+                    {
+                        continue;
+                    }
+
+                    previousValues[measurement.Measure] = text;
+
+                    draw = true;
 
                     image.Mutate(Draw);
                 }


### PR DESCRIPTION
- Fix implementation of custom UnitsNet units.
- Avoid redrawing `MultiLineTheme` when a new measurement would result in no textual changes. Previously it could redraw e.g. `200.1` and `200.2` as `"200"`, twice.
- Add `Measure.P0_5` to `MultiLineTheme`.
- Some random small perf improvements.